### PR TITLE
Fix for undefined `event.sender` in Electron ≥ 25

### DIFF
--- a/electron-observer.js
+++ b/electron-observer.js
@@ -23,7 +23,7 @@ function sessionWillDownload(event, download) {
 
 function downloadDone(event, state) {
   if (state != "completed") return
-  observer.emit("download-completed", event.sender)
+  observer.emit("download-completed", this)
 }
 
 module.exports = observer


### PR DESCRIPTION
In Electron ≥ 25, `event.sender` is now `undefined` for events that are not IPC events. This breaks `gatemaker` with

```
TypeError: Cannot read properties of undefined (reading 'getSavePath')
```

This was apparently an intended change upstream; see

- electron/electron#38566

Instead use `this`, which has the same value in Electron < 25 and remains usable in Electron ≥ 25.

- Fixes #5.